### PR TITLE
fix(deps): bump numpy from <2.0.0 to >=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4>=4.12.2
-numpy<2.0.0
+numpy>=2.0.0
 opencv_python>=4.8.0.76
 requests>=2.31.0
 onnxruntime>=1.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
 [options.extras_require]
 captcha =
     beautifulsoup4>=4.12.2
-    numpy<2.0.0
+    numpy>=2.0.0
     opencv_python>=4.8.0.76
     onnxruntime>=1.14
 


### PR DESCRIPTION
Bumps the minimum required version of numpy to 2.0.0 to avoid version conflicts with other major libraries.

I confirmed that `test_onnx` has passed successfully with this change.