### PR TITLE
Adding functions to find associated devices of a plant and inverters data.

### DIFF
--- a/src/fusion_solar_py/client.py
+++ b/src/fusion_solar_py/client.py
@@ -660,12 +660,13 @@ class FusionSolarClient:
 
 
     @logged_in
-    def get_device_ids(self) -> list:
-        """gets the devices associated to a given parent_id (can be a plant or a company/account)
+    def get_device_ids(self, parent_id: str = None) -> list:
+        """gets the devices associated to a given parent_id
+        :param parent_id: the parent_id (can be a plant or a company/account)
         returns a dictionary mapping device_type to device_id"""
         url = f"https://{self._huawei_subdomain}.fusionsolar.huawei.com/rest/neteco/web/config/device/v1/device-list"
         params = {
-            "conditionParams.parentDn": self._company_id,  # can be a plant or company id
+            "conditionParams.parentDn": self._company_id if parent_id is None else parent_id,  # can be a plant or company id
             "conditionParams.mocTypes": "20814,20815,20816,20819,20822,50017,60066,60014,60015,23037",  # specifies the types of devices
             "_": round(time.time() * 1000),
         }

--- a/src/fusion_solar_py/client.py
+++ b/src/fusion_solar_py/client.py
@@ -428,7 +428,7 @@ class FusionSolarClient:
         )
 
         # the new API returns a 500 exception if the subdomain is incorrect
-        if r.status_code == 500:
+        if r.status_code in [500, 400]:
             try:
                 data = r.json()
 
@@ -678,6 +678,8 @@ class FusionSolarClient:
         for device in device_data["data"]:
             devices += [dict(type=device["mocTypeName"], deviceDn=device["dn"])]
         return devices
+
+
     @logged_in
     def get_historical_data(self, signal_ids: list[str] = ['30014', '30016', '30017'], device_dn:str = None, date: datetime = datetime.now() ) -> dict:
         """retrieves historical data for specified signals and device

--- a/src/fusion_solar_py/client.py
+++ b/src/fusion_solar_py/client.py
@@ -574,7 +574,7 @@ class FusionSolarClient:
         return power_obj["data"]
 
     @logged_in
-    def get_device_real_kpi(self, device_id: str, signal_ids: list[int] | list[str] = None) -> dict:
+    def get_device_data(self, device_id: str, signal_ids: list[int] | list[str] = None) -> dict:
         """
         Retrieves measurements for the specified device and signals.
         Each MPPT ID follow this logic :

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -81,7 +81,7 @@ class FusionSolarClientTest(TestCase):
 
         device_ids = client.get_device_ids()
         inverters = list(filter(lambda e: e['type'] == 'Inverter', device_ids))
-        inverter_id = 'NE=190024725' #inverters[0]['deviceDn']
+        inverter_id = inverters[0]['deviceDn']
 
         device_data = client.get_device_data(inverter_id, [11001, 11002])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -76,6 +76,20 @@ class FusionSolarClientTest(TestCase):
         self.assertIsNotNone((current_plant_data))
         self.assertTrue(current_plant_data["yearEnergy"] > 0)
 
+    def test_get_device_data(self):
+        client = FusionSolarClient(self.user, self.password, self.subdomain)
+
+        device_ids = client.get_device_ids()
+        inverters = list(filter(lambda e: e['type'] == 'Inverter', device_ids))
+        inverter_id = 'NE=190024725' #inverters[0]['deviceDn']
+
+        device_data = client.get_device_data(inverter_id, [11001, 11002])
+
+        self.assertIsNotNone(device_data.get("signals"))
+        signals = device_data["signals"]
+        self.assertIsNotNone(signals.get("11001"))
+        self.assertIsNotNone(signals.get("11002"))
+
     def test_get_plant_stats(self):
         client = FusionSolarClient(self.user, self.password, self.subdomain)
 
@@ -111,6 +125,7 @@ class FusionSolarClientTest(TestCase):
 
         # get the device ids
         device_ids = client.get_device_ids()
+        plant_devices_ids = client.get_device_ids(plant_ids[0])
 
         self.assertTrue(len(device_ids) > 0)
         inverters = list(filter(lambda e: e['type'] == 'Inverter', device_ids))


### PR DESCRIPTION
This PR adds support for retrieving device signal data and improves device filtering.

NEW FEATURES : 
 - `get_device_data(device_id: str, signal_ids: List)` : retrieves measurements (signals) of a device. The docstring explains how to get the signal_ids for MPPTs measurements. If `signal_ids` is None, it will be set to the IDs corresponding to the first 10 MPPTs voltage and intensity.

CHANGED : 
 - `get_device_ids` now accepts a `parent_id: str`. If not None, will be used to retrieve its associated devices (inverters, loggers, meters, ...). If None, the behavior remains unchanged..
 - if the domain is wrong, status code 400 will throw an exception (added with status code 500, so the original behavior remains unchanged)

Added tests covering:
  - `get_device_data`
  - Updated behavior of `get_device_ids`

(hoping this work is clean enough to be accepted, I want it to be used if it could help someone else encountering the same problems as I did!)