### PR TITLE
Fix captcha detection: login page is now a React SPA, HTML scraping never finds the field

### DIFF
--- a/src/fusion_solar_py/client.py
+++ b/src/fusion_solar_py/client.py
@@ -285,33 +285,33 @@ class FusionSolarClient:
         """
         # check if the import is available
         try:
-            import bs4
+            import bs4  # noqa: F401
         except ImportError:
             _LOGGER.error("Required libraries for CAPTCHA solving are not available. Please install the package using pip install fusion_solar_py[captcha].")
             raise Exception("Required libraries for CAPTCHA solving are not available.")
 
         _LOGGER.debug("Checking if captcha is required")
 
-        url = f"https://{self._login_subdomain}.fusionsolar.huawei.com/"
-        params = {
-            "service": "%2Funisess%2Fv1%2Fauth%3Fservice%3D%252Fnetecowebext%252Fhome%252Findex.html",
-        }
-        r = self._session.get(url=url, params=params)
+        # NOTE: the login page is served as a React SPA nowadays - the static
+        # HTML response never contains the "verificationCodeInput" element
+        # (it is only added to the DOM client-side by JS after the page's
+        # bundle runs), so the previous bs4-based scraping check below
+        # always returned False, even on accounts where a captcha genuinely
+        # is required. This function is only ever invoked by the
+        # with_solver decorator after a CaptchaRequiredException was raised
+        # from _login(), i.e. after the login response JSON itself already
+        # told us "verifyCodeCreate": true - so we can skip the HTML check
+        # entirely and go straight to fetching+solving the captcha image.
+        # See https://github.com/jgriss/FusionSolarPy/issues/53
+        captcha = self._get_captcha()
+        self._init_solver()
+        self._captcha_verify_code = self._captcha_solver.solve_captcha(captcha)
+        r = self._session.post(url=f"https://{self._login_subdomain}.fusionsolar.huawei.com/unisso/preValidVerifycode",
+                               data={"verifycode": self._captcha_verify_code, "index": 0})
         r.raise_for_status()
-        soup = bs4.BeautifulSoup(r.text, 'html.parser')
-        captcha_exists = soup.find(id="verificationCodeInput")
-        if captcha_exists:
-            captcha = self._get_captcha()
-            self._init_solver()
-            self._captcha_verify_code = self._captcha_solver.solve_captcha(captcha)
-            r = self._session.post(url=f"https://{self._login_subdomain}.fusionsolar.huawei.com/unisso/preValidVerifycode",
-                                   data={"verifycode": self._captcha_verify_code, "index": 0})
-            r.raise_for_status()
-            if r.text != "success":
-                raise AuthenticationException("Login failed: captcha prevalidverify fail.")
-            return True
-        else:
+        if r.text != "success":
             return False
+        return True
 
     def _get_captcha(self):
         url = f"https://{self._login_subdomain}.fusionsolar.huawei.com/unisso/verifycode"


### PR DESCRIPTION
## Problem
`_check_captcha()` scrapes the static login page HTML looking for an
element with `id="verificationCodeInput"` to decide whether a captcha
is required. The login page is now rendered client-side as a React SPA
(script bundles only, empty `<body>`), so that element is never present
in the HTML response - the check always returns `False`, and login
fails with `AuthenticationException("Login failed: Captcha required
but captcha not found.")` even when the account genuinely needs a
captcha. Matches #53.

## Root cause
`_check_captcha()` is only ever called from the `with_solver` decorator
after `_login()` already raised `CaptchaRequiredException`, which only
happens when the login response JSON contains `"verifyCodeCreate":
true`. In other words, by the time we reach `_check_captcha()`, we
already know a captcha is required from the API's own JSON response -
the HTML scraping step is redundant AND broken against the current
frontend.

## Fix
Remove the HTML scraping check; go straight to fetching + solving the
captcha image, exactly as the old "captcha found" branch already did.

## Testing
Verified end-to-end against a live account on the **European (EU5)
server**, `uni003eu5` subdomain: login flow (pubkey → validateUser →
captcha required → solve via bundled ONNX model → prevalidate →
re-login with verifycode) completes successfully, and subsequent
authenticated API calls (`get_power_status`, `get_plant_ids`) work
correctly. Confirmed the bug was present before this fix (same
account, same credentials).

I have not been able to test against other regions (e.g. China/APAC
servers) - if those use a different login frontend that still serves
the old server-rendered HTML with `verificationCodeInput`, this change
should be harmless there too, since the only thing removed is a check
that would have returned `True` anyway on that markup. But flagging
this in case a region-specific regression shows up.

Fixes #53